### PR TITLE
Chef::Mixin::Language was deprecated and now fails with an error in Chef 14

### DIFF
--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -18,7 +18,6 @@
 #
 
 require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
 require 'tsort'
 require 'open-uri'
 require 'tempfile'

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -18,7 +18,6 @@
 #
 
 require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
 include Chef::Mixin::ShellOut
 
 action :install do


### PR DESCRIPTION
Chef::Mixin::Language was deprecated and now fails with an error in Chef 14:

```
================================================================================                                                                                                                                                                                                                                               
Recipe Compile Error in /var/cache/chef/cookbooks/pacman/providers/group.rb                                                                                                                                                                                                                                                    
================================================================================                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                               
LoadError                                                                                                                                                                                                                                                                                                                      
---------                                                                                                                                                                                                                                                                                                                      
cannot load such file -- chef/mixin/language
```

Simply removing this line resolves the problem.